### PR TITLE
Remove Anvesha and Club Registration updates from Latest Updates section

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -3,8 +3,7 @@ Welcome to the content hub for your website!
 
 To update the content on your website, you o// --- EVENTS DATA ---
 const upcomingEvents = [
-    {
-        date: "02 FEB",
+   //  },ate: "02 FEB",
         title: "Know Your Faculty",
         description: "Organised by the CCIT, this short video series answers common questions in programming and helps you learn directly from our faculty experts."
     },


### PR DESCRIPTION
- Removed 'Anvesha '25' update entry from latestUpdates array
- Removed 'Club Registrations are Opening soon' update entry
- Latest Updates section now shows no content (can be hidden or populated with new updates)
- Cleaned up redundant update content as requested