### PR TITLE
Fix mobile responsive issues in leadership page and navbar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2162,6 +2162,12 @@ footer::before {
         height: 100px;
     }
 
+    /* Team member images for past secretaries and former advisors */
+    .team-member .member-image img {
+        width: 100px;
+        height: 100px;
+    }
+
     /* Filter buttons */
     .filter-btn {
         padding: 0.4rem 1rem;

--- a/pages/navbar.css
+++ b/pages/navbar.css
@@ -95,6 +95,10 @@
 .hamburger .bar { width: 25px; height: 2px; background-color: #1D1D1F; border-radius: 5px; transition: all 0.3s ease; }
 @media (max-width: 992px) {
     .logo span { display: none; }
+    .logo img { 
+        height: 40px; 
+        margin-right: 8px; 
+    }
     .hamburger { display: flex; }
     .nav-links { display: none; flex-direction: column; background-color: white; position: absolute; top: 70px; right: 0; width: 100%; text-align: center; box-shadow: 0 8px 16px rgba(0,0,0,0.1); padding-bottom: 20px; }
     .nav-links.active { display: flex; }


### PR DESCRIPTION
- Added mobile styles for past secretaries and former advisors images (.team-member .member-image img)
- Fixed image sizing to match other team member cards (100px x 100px) on mobile
- Improved logo visibility in mobile navbar by reducing size and adjusting margins
- Ensured consistent styling across all team member sections in mobile view
- Logo now properly visible at 40px height with 8px margin on mobile devices